### PR TITLE
allow user to pass token_path #35

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -94,6 +94,10 @@ you can specify the path to the credentials as a second argument of the :code:`G
 
 
 
+.. note::   You can also specify the :code:`token_path` parameter, which overrides
+            the default :code:`token.pickle` location. That could be useful if you want to save
+            the file elsewhere, or if you have multiple google accounts.
+
 
 .. _`Calendar API Quickstart`: https://developers.google.com/calendar/quickstart/python#step_1_turn_on_the
 .. _datetime: https://docs.python.org/3/library/datetime.html

--- a/gcsa/google_calendar.py
+++ b/gcsa/google_calendar.py
@@ -29,7 +29,8 @@ class GoogleCalendar:
                  calendar='primary',
                  credentials_path=None,
                  read_only=False,
-                 application_name=None):
+                 application_name=None,
+                 token_path=None):
         """Represents Google Calendar of the user.
 
         :param calendar:
@@ -40,12 +41,15 @@ class GoogleCalendar:
                 if require read only access. Default: False
         :param application_name:
                 name of the application. Default: None
+        :param token_path:
+                path to save authenticated token file. Default: "token.pickle"
         """
         credentials_path = credentials_path or _get_default_credentials_path()
         self._credentials_dir, self._credentials_file = os.path.split(credentials_path)
 
         self._scopes = [self._READ_WRITE_SCOPES + ('.readonly' if read_only else '')]
         self._application_name = application_name
+        self._token_path = token_path
 
         self.calendar = calendar
         credentials = self._get_credentials()
@@ -53,7 +57,8 @@ class GoogleCalendar:
 
     def _get_credentials(self):
         _credentials_path = os.path.join(self._credentials_dir, self._credentials_file)
-        _token_path = os.path.join(self._credentials_dir, 'token.pickle')
+        _default_token_path = os.path.join(self._credentials_dir, 'token.pickle')
+        _token_path = self._token_path or _default_token_path
 
         credentials = None
 


### PR DESCRIPTION
this allows you to specify the token
path, so that an old pickle file doesn't get
used by default, if there are multiple
google accounts being used with gcsa

I included it as the last parameter to `GoogleCalendar`

```diff
-                 application_name=None):
+                 application_name=None,
+                 token_path=None):
```

Even though I think it makes more sense to have it after the credential path, if someone used only positional arguments, that would make this a breaking change. Putting the parameter on the end keeps backwards compatibility.

I tested this with my usecase:

```diff
 def create_calendar(email: str, credential_file: str) -> GoogleCalendar:
-    return GoogleCalendar(email, credential_file)
+    return GoogleCalendar(email, credential_file, token_path=os.path.join(os.environ["HOME"], ".credentials", f"{email}.pickle"))
```

and it works properly.

Built the docs, screenshots:

![](https://i.imgur.com/MYfx0Y5.png)

![](https://i.imgur.com/xcHKKID.png)