### PR TITLE
Fix gadget_serializer objects raising KeyErros due to non compliant response by the API

### DIFF
--- a/gcsa/gadget.py
+++ b/gcsa/gadget.py
@@ -13,6 +13,7 @@ class Gadget:
             height=None,
             width=None,
             preferences=None,
+            _serialized=False
     ):
         """
         A gadget that can extend the event.
@@ -44,11 +45,12 @@ class Gadget:
         def check_positive_integer(v, name):
             if v is not None and (not isinstance(v, int) or v <= 0):
                 raise ValueError('"{}" has to be a positive integer'.format(name))
-
-        check_not_empty(title, 'title')
-        check_not_empty(type_, 'type_')
-        check_not_empty(link, 'link')
-        check_not_empty(icon_link, 'icon_link')
+                
+        if not _serialized:
+            check_not_empty(title, 'title')
+            check_not_empty(type_, 'type_')
+            check_not_empty(link, 'link')
+            check_not_empty(icon_link, 'icon_link')
 
         if display and display not in (Gadget.ICON, Gadget.CHIP):
             raise ValueError('"display" has to be on of Gadget.ICON or Gadget.CHIP')

--- a/gcsa/gadget.py
+++ b/gcsa/gadget.py
@@ -45,7 +45,7 @@ class Gadget:
         def check_positive_integer(v, name):
             if v is not None and (not isinstance(v, int) or v <= 0):
                 raise ValueError('"{}" has to be a positive integer'.format(name))
-                
+
         if not _serialized:
             check_not_empty(title, 'title')
             check_not_empty(type_, 'type_')

--- a/gcsa/serializers/gadget_serializer.py
+++ b/gcsa/serializers/gadget_serializer.py
@@ -30,12 +30,13 @@ class GadgetSerializer(BaseSerializer):
     @staticmethod
     def _to_object(json_gadget):
         return Gadget(
-            title=json_gadget['title'],
-            type_=json_gadget['type'],
-            link=json_gadget['link'],
-            icon_link=json_gadget['iconLink'],
+            title=json_gadget.get('title', None),
+            type_=json_gadget.get('type', None),
+            link=json_gadget.get('link', None),
+            icon_link=json_gadget.get('iconLink', None),
             display=json_gadget.get('display', None),
             height=json_gadget.get('height', None),
             width=json_gadget.get('width', None),
-            preferences=json_gadget.get('preferences', None)
+            preferences=json_gadget.get('preferences', None),
+            _serialized=True
         )


### PR DESCRIPTION
Results coming from the `gadget_serializer ` should now skip sanity checks from the `Gadget` class as well as use .get() for fetching entries from the Gadget JSON Object returned by Google Calendar's API itself, thus avoiding errors when the returned object does not comply with the API specification as is the case with the issue this fixes.

closes #44 