### PR TITLE
Added default None to summary field of event serializer

### DIFF
--- a/gcsa/serializers/event_serializer.py
+++ b/gcsa/serializers/event_serializer.py
@@ -123,7 +123,7 @@ class EventSerializer(BaseSerializer):
             conference_solution = None
 
         return Event(
-            json_event.pop('summary'),
+            json_event.pop('summary', None),
             start=start,
             end=end,
             timezone=timezone,


### PR DESCRIPTION
This adds a default value of None to the summary field of the event serializer to fix KeyErrors resulting from event's with no summary. 