### PR TITLE
Fix the maximum number of overrideable reminders

### DIFF
--- a/gcsa/event.py
+++ b/gcsa/event.py
@@ -198,7 +198,7 @@ class Event:
 
     def add_reminder(self, reminder):
         """Adds reminder to an event. See :py:mod:`~gcsa.reminders`"""
-        if len(self.reminders) > 4:
+        if len(self.reminders) > 5:
             raise ValueError('The maximum number of override reminders is 5.')
         self.reminders.append(reminder)
 


### PR DESCRIPTION
Fixes #86. Now 5 reminders can be set. (I'm currently working on to be able easily add multiple reminders and faced this problem). 