### PR TITLE
Add calendar.import_event()

### DIFF
--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -128,6 +128,8 @@ Import event
 
     calendar.import_event(event)
 
+This operation is used to add a private copy of an existing event to a calendar.
+
 
 Move event to another calendar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -121,6 +121,14 @@ Update event
     calendar.update_event(event)
 
 
+Import event
+~~~~~~~~~~~~
+
+.. code-block:: python
+
+    calendar.import_event(event)
+
+
 Move event to another calendar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/gcsa/google_calendar.py
+++ b/gcsa/google_calendar.py
@@ -212,6 +212,27 @@ class GoogleCalendar:
         ).execute()
         return EventSerializer.to_object(event_json)
 
+    def import_event(self, event, **kwargs):
+        """Imports an event in the calendar
+
+        :param event:
+                Event object.
+        :param kwargs:
+                Additional API parameters.
+                See https://developers.google.com/calendar/v3/reference/events/import#optional-parameters
+
+        :return:
+                Created event object with id.
+        """
+        body = EventSerializer(event).get_json()
+        event_json = self.service.events().import_(
+            calendarId=self.calendar,
+            body=body,
+            conferenceDataVersion=1,
+            **kwargs
+        ).execute()
+        return EventSerializer.to_object(event_json)
+
     def update_event(
             self,
             event,

--- a/gcsa/google_calendar.py
+++ b/gcsa/google_calendar.py
@@ -215,6 +215,8 @@ class GoogleCalendar:
     def import_event(self, event, **kwargs):
         """Imports an event in the calendar
 
+        This operation is used to add a private copy of an existing event to a calendar.
+
         :param event:
                 Event object.
         :param kwargs:


### PR DESCRIPTION
I'm working on a CLI tool to import ICS files into GCal and noticed that the import endpoint wasn't implemented. So, here it is!