### PR TITLE
Update events.rst

### DIFF
--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -91,6 +91,7 @@ Create event
 .. code-block:: python
 
     from beautiful_date import Apr, hours
+    from gcsa.event import Event
 
     start = (22/Apr/2019)[12:00]
     end = start + 2 * hours


### PR DESCRIPTION
Import Event to create event example
it fixing the error (when not importing event) : 
TypeError: 'Event' object is not callable