### PR TITLE
More Reliable oAuth

### DIFF
--- a/gcsa/_services/authentication.py
+++ b/gcsa/_services/authentication.py
@@ -9,6 +9,8 @@ from google_auth_oauthlib.flow import InstalledAppFlow, WSGITimeout
 from google.auth.transport.requests import Request
 from google.auth.credentials import Credentials
 
+from gcsa.exceptions import FailedToAuthenticateError
+
 
 class AuthenticatedService:
     """Handles authentication of the `GoogleCalendar`"""
@@ -122,6 +124,9 @@ class AuthenticatedService:
                     )
                 except WSGITimeout:
                     print('Authentication flow timed out. Please try again.')
+
+            if credentials is None:
+                raise FailedToAuthenticateError
 
             if save_token:
                 with open(token_path, 'wb') as token_file:

--- a/gcsa/_services/authentication.py
+++ b/gcsa/_services/authentication.py
@@ -4,7 +4,7 @@ import glob
 from typing import List
 
 from googleapiclient import discovery
-from google_auth_oauthlib.flow import InstalledAppFlow
+from google_auth_oauthlib.flow import InstalledAppFlow, WSGITimeout
 from google.auth.transport.requests import Request
 from google.auth.credentials import Credentials
 
@@ -107,7 +107,12 @@ class AuthenticatedService:
             else:
                 credentials_path = os.path.join(credentials_dir, credentials_file)
                 flow = InstalledAppFlow.from_client_secrets_file(credentials_path, scopes)
-                credentials = flow.run_local_server(host=host, port=port, bind_addr=bind_addr)
+                try:
+                    credentials = flow.run_local_server(
+                        host=host, port=port, bind_addr=bind_addr, timeout_seconds=120
+                    )
+                except WSGITimeout:
+                    print('Authentication flow timed out. Please try again.')
 
             if save_token:
                 with open(token_path, 'wb') as token_file:

--- a/gcsa/_services/authentication.py
+++ b/gcsa/_services/authentication.py
@@ -2,6 +2,7 @@ import pickle
 import os.path
 import glob
 from typing import List
+import webbrowser
 
 from googleapiclient import discovery
 from google_auth_oauthlib.flow import InstalledAppFlow, WSGITimeout
@@ -93,7 +94,8 @@ class AuthenticatedService:
             save_token: bool,
             host: str,
             port: int,
-            bind_addr: str
+            bind_addr: str,
+            open_browser: bool = True
     ) -> Credentials:
         credentials = None
 
@@ -109,7 +111,14 @@ class AuthenticatedService:
                 flow = InstalledAppFlow.from_client_secrets_file(credentials_path, scopes)
                 try:
                     credentials = flow.run_local_server(
-                        host=host, port=port, bind_addr=bind_addr, timeout_seconds=120
+                        host=host, port=port, bind_addr=bind_addr, timeout_seconds=120,
+                        open_browser=open_browser
+                    )
+                except webbrowser.Error:
+                    # System has no default browser configured, retry without opening browser
+                    return AuthenticatedService._get_credentials(
+                        token_path, credentials_dir, credentials_file, scopes, save_token, host, port,
+                        bind_addr, open_browser=False
                     )
                 except WSGITimeout:
                     print('Authentication flow timed out. Please try again.')

--- a/gcsa/exceptions.py
+++ b/gcsa/exceptions.py
@@ -1,0 +1,2 @@
+class FailedToAuthenticateError(Exception):
+    'Failed to authenticate to Google APIs'

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup(
         "tzlocal>=4,<5",
         "google-api-python-client>=1.8",
         "google-auth-httplib2>=0.0.4",
-        "google-auth-oauthlib>=0.5,<2.0",
+        "google-auth-oauthlib>=1.2.1,<2.0",
         "python-dateutil>=2.7",
         "beautiful_date>=2.0.0",
     ],


### PR DESCRIPTION
Opening this draft PR for discussion.

* Set a timeout on the oauth callback listening server, such that it doesn't simply hang forever holding a port open (depends on googleapis/google-auth-library-python-oauthlib#363)
* Handle an edge case where the system has no configured browser, which fixes #187 

Also commit 2703518 will likely need to be updated to the actual version number once `google-auth-oauthlib` is released to pypi.